### PR TITLE
feat: enhance coordinate parsing to combine multiple segments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,49 @@
+# General Guidelines
 1. Challenge user's instructions, don't just follow them. If you see a flaw or problem, call it out.
 2. Asking questions to clarify the concepts and words that are ambiguous is highly encouraged.
 3. Raw materials contains images and text. When looking for information, consider both.
 4. If a question is beyond your knowledge, say so. Don't make up answers. And if you do, make it clear that it's a guess.
+
+
+# Python Coding Guidelines (TDD‑First Approach)
+
+## 🧪 Test-Driven Development Workflow
+
+1. **Red → Green → Refactor**  
+   - Write one small failing unit test (`pytest`). :contentReference[oaicite:1]{index=1}  
+   - Implement the minimal code to make it pass. :contentReference[oaicite:2]{index=2}  
+   - Refactor for clarity and maintainability without altering behavior. :contentReference[oaicite:3]{index=3}  
+   - Repeat: add next test, get it to pass, refactor. :contentReference[oaicite:4]{index=4}  
+
+2. **FIRST Principles for Test Design**  
+   - **F**ast, **I**solated, **R**epeatable, **S**elf‑validating, **T**imely. :contentReference[oaicite:5]{index=5}  
+   - Use AAA pattern: Arrange, Act, Assert. :contentReference[oaicite:6]{index=6}  
+
+3. **Test Case Structure**  
+   - Keep tests small and focused on a single behavior. :contentReference[oaicite:7]{index=7}  
+   - Name tests using *given_when_then* or descriptiveFunc_shouldDoX. :contentReference[oaicite:8]{index=8}  
+
+4. **Mocking Policy**  
+   - Mock external dependencies (DB, HTTP, time) to isolate units. :contentReference[oaicite:9]{index=9}  
+
+5. **Avoid Flaky Tests**  
+   - Ensure tests have no hidden dependencies or randomness. Use fixtures/seeded values. :contentReference[oaicite:10]{index=10}  
+
+
+## 🛠 Tooling & Quality
+
+- Use **pytest** as primary test runner; integrate `coverage.py`. :contentReference[oaicite:11]{index=11}  
+- Enforce style with **Black**, **Flake8**, **Pylint**. :contentReference[oaicite:12]{index=12}  
+
+## 🔁 Continuous Integration
+
+- Run full test suite and static checks on every commit/PR.  
+- Aim for high coverage, but focus on meaningful coverage (decision, branch). :contentReference[oaicite:13]{index=13}  
+
+
+
+## 📘 Best Practices & Mindsets
+
+- Apply **KISS**, **DRY**, **SOLID**, and separation of concerns. :contentReference[oaicite:14]{index=14}  
+- Commit small increments frequently (one test → one behavior). :contentReference[oaicite:15]{index=15}  
+- Tests are documentation: maintain them as part of codebase. :contentReference[oaicite:16]{index=16}  

--- a/scripts/test_coordinate_parsing.py
+++ b/scripts/test_coordinate_parsing.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the improved coordinate parsing that combines multiple bounding boxes.
+"""
+
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).parent))
+
+from tei_processor import TEIProcessor
+
+
+def test_coordinate_parsing():
+    """Test the new coordinate parsing logic."""
+    processor = TEIProcessor()
+    
+    # Test cases with multiple coordinate segments
+    test_cases = [
+        # Example from the user's observation
+        "3,312.00,193.02,252.00,7.40;3,312.00,202.02,252.00,7.40;3,312.00,211.02,252.00,7.40;3,312.00,220.02,36.13,7.40",
+        
+        # Single coordinate (should work as before)
+        "1,100.0,200.0,300.0,150.0",
+        
+        # Two segments
+        "2,50.0,100.0,200.0,50.0;2,50.0,160.0,200.0,40.0",
+        
+        # Empty string
+        "",
+        
+        # Invalid format
+        "invalid,coords,string"
+    ]
+    
+    print("Testing coordinate parsing with multiple segments...\n")
+    
+    for i, coords_str in enumerate(test_cases, 1):
+        print(f"Test Case {i}:")
+        print(f"  Input: {coords_str}")
+        
+        result = processor._parse_coordinates(coords_str)
+        
+        if result:
+            page, x, y, width, height = result
+            print(f"  Output: page={page}, x={x:.2f}, y={y:.2f}, width={width:.2f}, height={height:.2f}")
+            print(f"  Bounding box: ({x:.2f}, {y:.2f}) to ({x + width:.2f}, {y + height:.2f})")
+        else:
+            print("  Output: None (invalid coordinates)")
+        
+        print()
+    
+    # Specific test for the user's example
+    print("=== DETAILED ANALYSIS OF USER'S EXAMPLE ===")
+    user_coords = "3,312.00,193.02,252.00,7.40;3,312.00,202.02,252.00,7.40;3,312.00,211.02,252.00,7.40;3,312.00,220.02,36.13,7.40"
+    result = processor._parse_coordinates(user_coords)
+    
+    if result:
+        page, x, y, width, height = result
+        print("Combined bounding box:")
+        print(f"  Page: {page}")
+        print(f"  Top-left: ({x:.2f}, {y:.2f})")
+        print(f"  Bottom-right: ({x + width:.2f}, {y + height:.2f})")
+        print(f"  Size: {width:.2f} x {height:.2f}")
+        
+        print("\nIndividual segments:")
+        segments = user_coords.split(';')
+        for i, segment in enumerate(segments, 1):
+            parts = segment.split(',')
+            if len(parts) >= 5:
+                seg_x, seg_y, seg_w, seg_h = float(parts[1]), float(parts[2]), float(parts[3]), float(parts[4])
+                print(f"  Segment {i}: ({seg_x:.2f}, {seg_y:.2f}) size {seg_w:.2f}x{seg_h:.2f}")
+        
+        print(f"\n→ The combined box now encompasses all {len(segments)} segments!")
+    else:
+        print("Failed to parse coordinates")
+
+
+if __name__ == "__main__":
+    test_coordinate_parsing()


### PR DESCRIPTION
- Updated _parse_coordinates method to handle semicolon-separated coordinate segments
- Now combines all segments into a single encompassing bounding box
- Ensures complete figure/table/graphic regions are captured during PDF cropping
- Added comprehensive test script for coordinate parsing validation
- Updated coding guidelines in copilot instructions

Fixes issue where figures with multiple coordinate segments (lines/pieces) were only cropping the first segment instead of the complete region.